### PR TITLE
Pass file path to 'runInNewContext' for better stack traces

### DIFF
--- a/index.js
+++ b/index.js
@@ -68,7 +68,9 @@ module.exports = function (module, mocks, compiler) {
 
   log('mockrequiring ' + filepath);
   compiler = compiler || fs.readFileSync;
-  vm.runInNewContext(compiler(filepath), sandbox);
+  vm.runInNewContext(compiler(filepath), sandbox, {
+      filename: filepath
+  });
 
   return sandbox.module.exports;
 };


### PR DESCRIPTION
Errors in `mockrequire`d files are currently displayed as `evalmachine` which is not very helpful in troubleshooting.

This change passes the file path of the module to `runInNewContext`, so that the correct file name is shown in stack traces.